### PR TITLE
FIX for GitLab Enterprise Edition 11.6.9-ee

### DIFF
--- a/src/main/java/org/muehlbachler/gradle/plugin/dependencyupdatenotifier/gitlab/GitlabClient.java
+++ b/src/main/java/org/muehlbachler/gradle/plugin/dependencyupdatenotifier/gitlab/GitlabClient.java
@@ -12,6 +12,7 @@ import org.gradle.api.logging.Logger;
 import org.muehlbachler.gradle.plugin.dependencyupdatenotifier.BaseClient;
 import org.muehlbachler.gradle.plugin.dependencyupdatenotifier.model.gitlab.GitlabNotifierConfig;
 import org.muehlbachler.gradle.plugin.dependencyupdatenotifier.model.gitlab.issue.GitlabIssue;
+import org.muehlbachler.gradle.plugin.dependencyupdatenotifier.model.gitlab.issue.GitlabIssuePostFix;
 
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
@@ -29,6 +30,7 @@ public class GitlabClient extends BaseClient {
 
     JsonAdapter<List<GitlabIssue>> issueListAdapter;
     JsonAdapter<GitlabIssue> issueAdapter;
+    JsonAdapter<GitlabIssuePostFix> issuePostFixAdapter;
 
     public GitlabClient(final GitlabNotifierConfig config, final Logger logger) {
         this.logger = logger;
@@ -38,6 +40,7 @@ public class GitlabClient extends BaseClient {
         final Moshi moshi = new Moshi.Builder().build();
         issueListAdapter = moshi.adapter(gitlabIssueListType);
         issueAdapter = moshi.adapter(GitlabIssue.class);
+        issuePostFixAdapter = moshi.adapter(GitlabIssuePostFix.class);
 
         getRequestBuilder()
                 .addHeader(TOKEN, config.getToken());
@@ -58,7 +61,7 @@ public class GitlabClient extends BaseClient {
     }
 
     public GitlabIssue createIssue(final GitlabIssue issue) throws IOException {
-        final String json = issueAdapter.toJson(issue);
+        final String json = issuePostFixAdapter.toJson(new GitlabIssuePostFix(issue));
         final RequestBody requestBody = RequestBody.create(JSON, json);
         final Request request = getRequestBuilder()
                 .url(String.format("%s/projects/%s/issues", config.getUrl(), config.getProjectId()))

--- a/src/main/java/org/muehlbachler/gradle/plugin/dependencyupdatenotifier/model/gitlab/issue/GitlabIssuePostFix.java
+++ b/src/main/java/org/muehlbachler/gradle/plugin/dependencyupdatenotifier/model/gitlab/issue/GitlabIssuePostFix.java
@@ -1,0 +1,52 @@
+package org.muehlbachler.gradle.plugin.dependencyupdatenotifier.model.gitlab.issue;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.Json;
+import lombok.Data;
+import org.w3c.dom.html.HTMLImageElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+/*
+    This class is a FIX for GitLab Enterprise Edition 11.6.9-ee
+    In the documentation, it should always be String, although in this version
+    POST uses a String and GET uses a List
+*/
+@Data
+public class GitlabIssuePostFix {
+    @Json(name = "project_id")
+    Long projectId;
+    GitlabAuthor author;
+    String description;
+    List<GitlabAuthor> assignees;
+    String labels;
+    Long id;
+    String title;
+    @Json(name = "web_url")
+    String webUrl;
+
+    public GitlabIssuePostFix(GitlabIssue original){
+        setProjectId(original.getProjectId());
+        setAuthor(original.getAuthor());
+        setDescription(original.getDescription());
+        setAssignees(original.getAssignees());
+        setLabels(String.join(",", original.getLabels()));
+        setId(original.getId());
+        setTitle(original.getTitle());
+        setWebUrl(original.getWebUrl());
+    }
+
+    public GitlabIssue toGitlabIssue(){
+        return new GitlabIssue()
+            .setProjectId(projectId)
+            .setAuthor(author)
+            .setDescription(description)
+            .setAssignees(assignees)
+            .setLabels(Arrays.asList(labels.split(",")))
+            .setId(id)
+            .setTitle(title)
+            .setWebUrl(webUrl);
+    }
+}


### PR DESCRIPTION
Inconsistency in the Issues API of the `Enterprise Edition 11.6.9-ee` version of Gitlab. In the documentation, it should always be String, although in this version
POST uses a String and GET uses a List.